### PR TITLE
[main] chore: add minimumReleaseAge to delay dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,5 +11,6 @@
   "dependencyDashboard": true,
   "assignees": ["kkhys"],
   "labels": ["type: bump-version"],
-  "assignAutomerge": true
+  "assignAutomerge": true,
+  "minimumReleaseAge": "3 days"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320


### PR DESCRIPTION
- Add `minimumReleaseAge: "3 days"` to Renovate config to avoid adopting freshly released packages
- Add `minimumReleaseAge: 4320` to pnpm-workspace.yaml for consistent release age enforcement