### PR TITLE
fix: update rustls-webpki to 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Update `rustls-webpki` from 0.103.10 to 0.103.13 to fix 3 security vulnerabilities
- RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104

## Test plan
- [ ] `cargo audit` passes with no errors
- [ ] CI Security Audit job passes