### PR TITLE
[main] fix: use changelog-github in changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
-    "@changesets/get-github-info",
+    "@changesets/changelog-github",
     {
       "repo": "kkhys/gh-labeler"
     }

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "yaml": "2.9.0"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "0.7.0",
     "@changesets/cli": "2.31.0",
-    "@changesets/get-github-info": "0.8.0",
     "@types/node": "24.13.3",
     "@vitest/coverage-v8": "4.1.10",
     "lefthook": "2.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,12 +27,12 @@ importers:
         specifier: 2.9.0
         version: 2.9.0
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: 0.7.0
+        version: 0.7.0
       '@changesets/cli':
         specifier: 2.31.0
         version: 2.31.0(@types/node@24.13.3)
-      '@changesets/get-github-info':
-        specifier: 0.8.0
-        version: 0.8.0
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -90,6 +90,9 @@ packages:
 
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+
+  '@changesets/changelog-github@0.7.0':
+    resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
 
   '@changesets/cli@2.31.0':
     resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
@@ -1040,6 +1043,10 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
@@ -1653,6 +1660,14 @@ snapshots:
   '@changesets/changelog-git@0.2.1':
     dependencies:
       '@changesets/types': 6.1.0
+
+  '@changesets/changelog-github@0.7.0':
+    dependencies:
+      '@changesets/get-github-info': 0.8.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/cli@2.31.0(@types/node@24.13.3)':
     dependencies:
@@ -2358,6 +2373,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dotenv@8.6.0: {}
 
   enquirer@2.4.1:
     dependencies:


### PR DESCRIPTION
- Fix the Release workflow crash: `changeset version` failed with "Could not resolve changelog generation functions"
- `.changeset/config.json` pointed at `@changesets/get-github-info`, which is the helper library `changelog-github` builds on and exports no changelog functions; point it at `@changesets/changelog-github` instead
- Swap devDependencies accordingly: `@changesets/get-github-info` → `@changesets/changelog-github` (0.7.0, exact-pinned)
- Verified locally: `changeset version` now bumps to 1.0.0 and generates the GitHub-linked changelog, then the working tree was restored
- Merging this triggers the Release workflow via the push trigger, which should open the "chore: version packages" PR