### PR TITLE
[main] ci: publish to npm via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  # id-token backs npm Trusted Publishing (OIDC); publish auth uses no npm token
   id-token: write
 
 jobs:
@@ -41,23 +42,12 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build
-
-      - name: Configure npm authentication
-        run: |
-          echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
-          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
-          npm whoami
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check Changesets Status (Dry Run)
         if: github.event.inputs.dry_run == 'true'
@@ -77,7 +67,6 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         if: github.event.inputs.dry_run != 'true' && steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
- Publishing with `NPM_TOKEN` failed with `ERR_PNPM_OTP_NON_INTERACTIVE`: npm demands an OTP for token-based writes, which CI cannot answer; tokens also expire, which already broke one release run today
- Remove all token plumbing (`registry-url` / `NODE_AUTH_TOKEN` on setup-node, the `Configure npm authentication` step, `NPM_TOKEN` on the changesets action) and rely on npm Trusted Publishing: pnpm 11 exchanges the workflow's OIDC identity (`id-token: write`, already granted) for short-lived publish credentials
- Prerequisite before merging: register the trusted publisher on npmjs.com — package `gh-labeler` → Settings → Trusted Publisher → GitHub Actions with organization `kkhys`, repository `gh-labeler`, workflow filename `release.yml`, environment blank
- After merge, the Release workflow re-runs on main with no changesets pending, so it goes straight to publishing the already-versioned 1.0.0
- Once 1.0.0 is out, the `NPM_TOKEN` secret can be deleted