### PR TITLE
[main] ci: drop duplicate GitHub Release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,32 +68,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create GitHub Release
-        if: github.event.inputs.dry_run != 'true' && steps.changesets.outputs.published == 'true'
-        run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-
-          {
-            echo "## Release v${PACKAGE_VERSION}"
-            echo ""
-            echo "### Installation"
-            echo ""
-            echo '```bash'
-            echo "npm install -g ${PACKAGE_NAME}"
-            echo '```'
-            echo ""
-            echo "### Links"
-            echo "- [npm package](https://www.npmjs.com/package/${PACKAGE_NAME})"
-          } > release_notes.md
-
-          gh release create "v${PACKAGE_VERSION}" \
-            --title "Release v${PACKAGE_VERSION}" \
-            --notes-file release_notes.md \
-            --latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Dry Run Summary
         if: github.event.inputs.dry_run == 'true'
         run: |


### PR DESCRIPTION
- The 1.0.0 publish succeeded end to end (npm via trusted publishing, GitHub Release v1.0.0), but the run still ended red: the final `Create GitHub Release` step failed with `Release.tag_name already exists`
- `changesets/action` already creates the GitHub Release itself (`createGithubReleases` defaults to `true`) with the changelog entry as the body, which is richer than the hand-rolled notes (install snippet + links)
- Remove the redundant step so future publish runs finish green