### PR TITLE
[main] feat: add extends for inheriting base configs

### DIFF
--- a/.changeset/heavy-planets-extend.md
+++ b/.changeset/heavy-planets-extend.md
@@ -1,0 +1,5 @@
+---
+"gh-labeler": minor
+---
+
+Add `extends` to the config object form: inherit labels from base configs (a local path like `./base.yml` or another repository as `owner/repo[:path]`), merged in order with the extending file's own labels overriding by name (case-insensitive). `delete: true` cancels an inherited label, nesting is supported with cycle detection, and `prune` is never inherited from a base. `validate` stays offline and resolves only local extends.

--- a/.claude/rules/config-module.md
+++ b/.claude/rules/config-module.md
@@ -22,9 +22,16 @@ paths:
 
 ## Config Document Forms
 
-- Two accepted shapes: a bare array of labels, or an object `{ "$schema"?, "prune"?, "labels": [...] }`
+- Two accepted shapes: a bare array of labels, or an object `{ "$schema"?, "prune"?, "extends"?, "labels": [...] }`
 - `serializeConfigDocument()` always emits the object form with editor schema support (`$schema` for JSON, `yaml-language-server` directive for YAML)
 - `schema/labels.schema.json` is the source of truth for the config shape — keep it in sync with `validateLabelSpec()` and `normalizeConfigDocument()`
+
+## Extends
+
+- `extends` (object form only): string or array; each ref is a local path starting with `./`, `../`, or `/` (relative to the extending file) or `owner/repo[:path]`
+- Bases merge in listed order, the extending file's `labels` apply last; override replaces the whole entry, keyed by case-insensitive name — `resolveConfigExtends()` for local configs, resolved inside `fetchRemoteConfig()` for remote ones
+- `prune` is never inherited from a base config; nesting is allowed, cycles are rejected; paths inside a remote config resolve within that same repository and must not escape it
+- Cross-file alias contradictions are re-checked after merging (`validateMergedAliases()`); `validate` stays offline, so remote extends fail there with a hint
 
 ## File Format Support
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,10 @@ labels:
     aliases: [defect] # optional: old names to rename from
     delete: false # optional: true = delete this label if present (name alone suffices then)
 prune: false # optional: true = delete labels not declared above
+extends: [org/label-config] # optional: base config(s) to inherit labels from
 ```
+
+`extends` (object form only) accepts a string or array: each entry is a local path starting with `./`, `../`, or `/` (relative to the extending file) or `owner/repo[:path]` (fetched like `--from`). Bases merge in listed order, then the file's own `labels` apply last; an entry overrides an inherited one with the same name (case-insensitive) as a whole, and `delete: true` cancels an inherited label. `prune` is never inherited — only the directly loaded config decides it. Nesting is allowed; cycles are a config error. Paths inside a config fetched from another repository resolve within that same repository. `validate` stays offline and resolves only local paths; configs extending another repository need `plan`/`sync` (config error otherwise).
 
 A bare top-level array of labels is also accepted. Label names must be unique within the config (case-insensitive, matching GitHub); duplicates are rejected when the config is loaded. Aliases must not repeat across entries or collide with any declared label name (also case-insensitive); such contradictions are rejected too.
 
@@ -198,7 +201,7 @@ Imports use Node subpath imports (`#core/planner.js`, `#errors.js`, …) declare
 - **`core/similarity.ts`** — Levenshtein distance, `SIMILARITY_THRESHOLD` (0.7), `calculateLabelSimilarity()`
 - **`core/planner.ts`** — `planSync()` pure planning producing `PlannedOperation[]` (`create`/`update`/`rename`/`delete`/`keep`) + `unmanaged` list
 - **`core/syncer.ts`** — `applyPlan()` execution with per-operation failure collection, `buildReport()` → `SyncReport` (status/exit code/idempotence)
-- **`config/index.ts`** — config parsing (bare array or `{labels, prune}` object form), format detection, convention file search (`CONVENTION_CONFIG_FILES`), stdin loading, remote config via `RemoteFileFetcher`, `serializeConfigDocument()` (init/export output with `$schema`)
+- **`config/index.ts`** — config parsing (bare array or `{labels, prune, extends}` object form), format detection, convention file search (`CONVENTION_CONFIG_FILES`), stdin loading, remote config via `RemoteFileFetcher`, `extends` resolution (`resolveConfigExtends()`: name-keyed merge, cycle detection, prune never inherited), `serializeConfigDocument()` (init/export output with `$schema`)
 - **`github/context.ts`** — zero-config inference: token (`--token` → `GITHUB_TOKEN` → `GH_TOKEN` → `gh auth token`), repository (arg → `GITHUB_REPOSITORY` → origin git remote)
 - **`github/client.ts`** — `GitHubClient` wrapping Octokit, `LabelService` interface (DI boundary), `GitHubLabel`, Contents API fetch for remote configs
 - **`output/report.ts`** — stable snake_case JSON envelope (`reportEnvelope`, `errorEnvelope`, `REPORT_SCHEMA_VERSION`)
@@ -244,7 +247,7 @@ Imports use Node subpath imports (`#core/planner.js`, `#errors.js`, …) declare
 - Tests live in `tests/*.test.ts`, discovered by vitest's default include pattern (no vitest config file); helpers in `tests/helpers.ts`
 - **Planning tests** (`planner.test.ts`) — pure `planSync()` output, matching priority, prune semantics
 - **Sync tests** (`syncer.test.ts`) — `applyPlan()` against `MockLabelService`/`FailingLabelService`, dry-run, failure collection, report statuses
-- **Config tests** (`config.test.ts`) — both document forms, format auto-detect, convention priority, remote fetch with a fake fetcher, serialization round-trips
+- **Config tests** (`config.test.ts`) — both document forms, format auto-detect, convention priority, remote fetch with a fake fetcher, extends resolution (merge order, overrides, cycles, offline failure), serialization round-trips
 - **Context tests** (`context.test.ts`) — repo/token resolution priority, git URL parsing (env vars saved/restored per test)
 - **Report tests** (`report.test.ts`) — envelope shape stability (snake_case, `schema_version`)
 - Environment-dependent behavior (`gh auth token` fallback) must not make tests fail on developer machines

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Summary: 1 to create, 1 to update, 1 to rename, 8 unchanged
 - Zero-config — repository inferred from the `origin` remote (or `GITHUB_REPOSITORY` in Actions), token from `GITHUB_TOKEN` / `GH_TOKEN` / the `gh` CLI. Inside a clone, `gh-labeler sync` just works
 - Safe by default — labels are deleted only when flagged `delete: true` or when you opt into `--prune`; interactive syncs confirm deletions first
 - Smart renames — alias matching plus Levenshtein similarity turn would-be delete+create pairs into renames that preserve label history on issues and PRs
+- Shareable configs — `extends` inherits labels from a base config (local or in another repository) and overrides them per repository; `--from` syncs straight from a central repo
 - Built for AI agents — `--json` gives every state-reporting command a versioned, structured envelope; errors carry machine-readable codes and actionable hints; exit codes are systematic
 - Self-describing config — a published JSON Schema powers editor autocomplete in both JSON and YAML
 
@@ -73,6 +74,23 @@ prune: false # true = delete labels not declared here
 ```
 
 A bare array of labels (without the `labels:` key) is also accepted. Colors are 6-digit hex with a `#` prefix.
+
+### Extending a shared config
+
+A config can inherit labels from one or more base configs with `extends` — keep an organization-wide base in one repository and add or override per-repository labels on top:
+
+```yaml
+extends: my-org/label-config # or "owner/repo:path/to/labels.yml", or "./base.yml"
+labels:
+  - name: bug
+    color: "#ff0000" # overrides the base "bug" entirely (same name, case-insensitive)
+  - name: needs-triage
+    color: "#ededed" # added on top of the base set
+  - name: wontfix
+    delete: true # cancels an inherited label
+```
+
+Bases merge in the listed order, then the file's own `labels` win. Overriding replaces the whole entry, and `extends` can nest (cycles are rejected). `prune` is never inherited from a base — only the config you load directly decides it. Local paths (`./`, `../`, `/`) resolve relative to the extending file; inside a config fetched from another repository they resolve within that same repository. Note that `validate` is offline, so it resolves only local paths — use `plan` to check configs that extend another repository.
 
 ## Commands
 

--- a/schema/labels.schema.json
+++ b/schema/labels.schema.json
@@ -12,8 +12,18 @@
         "labels": { "$ref": "#/$defs/labelArray" },
         "prune": {
           "type": "boolean",
-          "description": "Delete repository labels that are not declared in `labels`. Default: false.",
+          "description": "Delete repository labels that are not declared in `labels`. Default: false. Never inherited through `extends`.",
           "default": false
+        },
+        "extends": {
+          "description": "Base config(s) to inherit labels from. Each entry is a path starting with './', '../', or '/' (relative to this file) or 'owner/repo[:path]' for another repository. Bases merge in order; this file's labels override inherited ones by name (case-insensitive).",
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          ]
         }
       },
       "required": ["labels"],

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,7 @@ import {
   loadConfigFile,
   loadConfigFromStdin,
   parseRemoteConfigRef,
+  resolveConfigExtends,
   serializeConfigDocument,
 } from "#config/index.js";
 import { resolveRepository, resolveToken } from "#github/context.js";
@@ -86,15 +87,19 @@ async function run(command: string, json: boolean, fn: () => Promise<number>): P
   }
 }
 
-function loadLocalConfig(configOption: string | undefined): {
+interface LocalConfig {
   config: LabelConfigFile;
   source: string;
-} {
+  /** Null when the config came from stdin; extends paths then use the cwd. */
+  path: string | null;
+}
+
+function loadLocalConfig(configOption: string | undefined): LocalConfig {
   if (configOption === "-") {
-    return { config: loadConfigFromStdin(), source: "stdin" };
+    return { config: loadConfigFromStdin(), source: "stdin", path: null };
   }
   if (configOption) {
-    return { config: loadConfigFile(configOption), source: configOption };
+    return { config: loadConfigFile(configOption), source: configOption, path: configOption };
   }
   const conventionPath = findConventionConfig(process.cwd());
   if (!conventionPath) {
@@ -103,7 +108,7 @@ function loadLocalConfig(configOption: string | undefined): {
       `Searched for: ${CONVENTION_CONFIG_FILES.join(", ")}. Run \`gh-labeler init\` to create one, or pass --config.`,
     );
   }
-  return { config: loadConfigFile(conventionPath), source: conventionPath };
+  return { config: loadConfigFile(conventionPath), source: conventionPath, path: conventionPath };
 }
 
 interface PreparedPlan {
@@ -123,12 +128,14 @@ async function preparePlan(repoArg: string | undefined, opts: SyncOptions): Prom
   const token = resolveToken(opts.token);
   const repository = resolveRepository(repoArg);
 
-  // Load local config before any network call so config mistakes fail fast.
+  // Parse the local config before any network call so config mistakes fail
+  // fast; extends refs may point at other repositories, so they resolve after
+  // the client connects.
   let config: LabelConfigFile | null = null;
+  let local: LocalConfig | null = null;
   if (!opts.from) {
-    const { config: localConfig, source } = loadLocalConfig(opts.config);
-    config = localConfig;
-    note(opts.json, `Config: ${source}`);
+    local = loadLocalConfig(opts.config);
+    note(opts.json, `Config: ${local.source}`);
   }
 
   const client = await GitHubClient.connect(token, repository);
@@ -137,6 +144,8 @@ async function preparePlan(repoArg: string | undefined, opts: SyncOptions): Prom
     const ref = parseRemoteConfigRef(opts.from);
     config = await fetchRemoteConfig(client, ref);
     note(opts.json, `Config: ${opts.from} (remote)`);
+  } else if (local) {
+    config = await resolveConfigExtends(local.config, local.path, client);
   }
 
   if (!config) {
@@ -179,8 +188,11 @@ async function planAction(repoArg: string | undefined, opts: PlanCommandOptions)
   return report.exitCode;
 }
 
-function validateAction(opts: ValidateOptions): Promise<number> {
-  const { config, source } = loadLocalConfig(opts.config);
+async function validateAction(opts: ValidateOptions): Promise<number> {
+  const { config: parsed, source, path } = loadLocalConfig(opts.config);
+  // No fetcher: validate stays offline. Local extends resolve; remote refs
+  // fail with a hint pointing at `plan`.
+  const config = await resolveConfigExtends(parsed, path);
   const prune = config.prune ?? false;
 
   if (opts.json) {
@@ -201,7 +213,7 @@ function validateAction(opts: ValidateOptions): Promise<number> {
       }.`,
     );
   }
-  return Promise.resolve(EXIT_CODES.SUCCESS);
+  return EXIT_CODES.SUCCESS;
 }
 
 async function syncAction(repoArg: string | undefined, opts: SyncOptions): Promise<number> {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, posix, resolve } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { parseRepository, type RepositoryRef } from "#github/context.js";
 import { ConfigError } from "#errors.js";
@@ -30,6 +30,8 @@ export interface LabelConfigFile {
   labels: ConfigEntry[];
   /** Delete repository labels that are absent from `labels`. */
   prune?: boolean;
+  /** Unresolved base config refs; absent once extends resolution has run. */
+  extends?: string[];
 }
 
 export function detectFormatFromPath(path: string): ConfigFormat {
@@ -137,7 +139,7 @@ function normalizeConfigDocument(data: unknown): LabelConfigFile {
   }
 
   if (typeof data === "object" && data !== null) {
-    const { labels, prune } = data as Record<string, unknown>;
+    const { labels, prune, extends: extendsRaw } = data as Record<string, unknown>;
     if (!Array.isArray(labels)) {
       throw new ConfigError(
         'Config object must contain a "labels" array',
@@ -153,6 +155,9 @@ function normalizeConfigDocument(data: unknown): LabelConfigFile {
       }
       config.prune = prune;
     }
+    if (extendsRaw !== undefined) {
+      config.extends = normalizeExtendsField(extendsRaw);
+    }
     return config;
   }
 
@@ -160,6 +165,17 @@ function normalizeConfigDocument(data: unknown): LabelConfigFile {
     'Config must be a label array or an object with a "labels" array',
     "Run `gh-labeler init` to generate a valid starting point.",
   );
+}
+
+function normalizeExtendsField(raw: unknown): string[] {
+  const list = typeof raw === "string" ? [raw] : raw;
+  if (!Array.isArray(list) || list.some((item) => typeof item !== "string" || item.trim() === "")) {
+    throw new ConfigError(
+      '"extends" must be a string or an array of non-empty strings',
+      'Each entry is a path starting with "./", "../", or "/" (relative to this config), or "owner/repo[:path]".',
+    );
+  }
+  return list as string[];
 }
 
 export function loadConfigFile(path: string): LabelConfigFile {
@@ -249,14 +265,10 @@ export function parseRemoteConfigRef(spec: string): RemoteConfigRef {
   return { ...parseRepository(repoPart), path };
 }
 
-/**
- * Fetch a label config from another repository. With an explicit path the
- * file must exist; without one the convention file names are tried in order.
- */
-export async function fetchRemoteConfig(
+async function fetchRemoteConfigFile(
   fetcher: RemoteFileFetcher,
   ref: RemoteConfigRef,
-): Promise<LabelConfigFile> {
+): Promise<{ config: LabelConfigFile; path: string }> {
   const repository = `${ref.owner}/${ref.repo}`;
 
   if (ref.path) {
@@ -264,7 +276,7 @@ export async function fetchRemoteConfig(
     if (content === null) {
       throw new ConfigError(`Remote config not found: ${repository}:${ref.path}`);
     }
-    return parseConfig(content, detectFormatFromPath(ref.path));
+    return { config: parseConfig(content, detectFormatFromPath(ref.path)), path: ref.path };
   }
 
   for (const filename of CONVENTION_CONFIG_FILES) {
@@ -273,7 +285,7 @@ export async function fetchRemoteConfig(
     // eslint-disable-next-line no-await-in-loop
     const content = await fetcher.fetchFile(ref.owner, ref.repo, filename);
     if (content !== null) {
-      return parseConfig(content, detectFormatFromPath(filename));
+      return { config: parseConfig(content, detectFormatFromPath(filename)), path: filename };
     }
   }
 
@@ -281,4 +293,239 @@ export async function fetchRemoteConfig(
     `No label config found in ${repository}`,
     `Searched for: ${CONVENTION_CONFIG_FILES.join(", ")}`,
   );
+}
+
+/**
+ * Fetch a label config from another repository, extends resolved. With an
+ * explicit path the file must exist; without one the convention file names
+ * are tried in order.
+ */
+export async function fetchRemoteConfig(
+  fetcher: RemoteFileFetcher,
+  ref: RemoteConfigRef,
+): Promise<LabelConfigFile> {
+  const { config, path } = await fetchRemoteConfigFile(fetcher, ref);
+  return resolveExtendedConfig(
+    config,
+    { kind: "remote", owner: ref.owner, repo: ref.repo, dir: posix.dirname(path) },
+    fetcher,
+    [remoteId(ref.owner, ref.repo, path)],
+  );
+}
+
+/** Where a config file came from; extends paths resolve against it. */
+type ConfigOrigin =
+  | { kind: "local"; dir: string }
+  | { kind: "remote"; owner: string; repo: string; dir: string };
+
+type ExtendsRef = { kind: "path"; path: string } | ({ kind: "repo" } & RemoteConfigRef);
+
+function parseExtendsRef(spec: string): ExtendsRef {
+  if (spec.startsWith("./") || spec.startsWith("../") || spec.startsWith("/")) {
+    return { kind: "path", path: spec };
+  }
+  try {
+    return { kind: "repo", ...parseRemoteConfigRef(spec) };
+  } catch {
+    throw new ConfigError(
+      `Invalid extends reference: "${spec}"`,
+      'Use a path starting with "./", "../", or "/" (relative to the extending config), or "owner/repo[:path]".',
+    );
+  }
+}
+
+/** Later entries override earlier ones by name, case-insensitively (GitHub semantics). */
+function mergeLabelEntries(base: ConfigEntry[], overlay: ConfigEntry[]): ConfigEntry[] {
+  const merged = [...base];
+  const indexByName = new Map(base.map((entry, i) => [entry.name.toLowerCase(), i] as const));
+  for (const entry of overlay) {
+    const key = entry.name.toLowerCase();
+    const at = indexByName.get(key);
+    if (at === undefined) {
+      indexByName.set(key, merged.length);
+      merged.push(entry);
+    } else {
+      merged[at] = entry;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Per-file alias invariants were checked at parse time, so a violation here
+ * means two extended configs contradict each other across files.
+ */
+function validateMergedAliases(labels: ConfigEntry[]): void {
+  const hint =
+    "The extended configs contradict each other; override one of the entries in the extending config.";
+  const names = new Set(labels.map((label) => label.name.toLowerCase()));
+  const aliasOwner = new Map<string, string>();
+  for (const label of labels) {
+    if (isLabelDeletion(label)) {
+      continue;
+    }
+    for (const alias of label.aliases ?? []) {
+      const key = alias.toLowerCase();
+      if (names.has(key)) {
+        throw new ConfigError(
+          `After merging extends: label "${label.name}": alias "${alias}" is also a declared label name`,
+          hint,
+        );
+      }
+      const owner = aliasOwner.get(key);
+      if (owner !== undefined) {
+        throw new ConfigError(
+          `After merging extends: label "${label.name}": duplicate alias "${alias}" (also claimed by label "${owner}")`,
+          hint,
+        );
+      }
+      aliasOwner.set(key, label.name);
+    }
+  }
+}
+
+function remoteId(owner: string, repo: string, path: string): string {
+  return `${owner.toLowerCase()}/${repo.toLowerCase()}:${path}`;
+}
+
+function assertNoExtendsCycle(stack: string[], id: string): void {
+  if (stack.includes(id)) {
+    throw new ConfigError(
+      `Circular extends: ${[...stack, id].join(" -> ")}`,
+      "A config cannot extend itself, directly or through other configs.",
+    );
+  }
+}
+
+function requireFetcher(fetcher: RemoteFileFetcher | undefined, spec: string): RemoteFileFetcher {
+  if (!fetcher) {
+    throw new ConfigError(
+      `Cannot resolve extends "${spec}" without GitHub access`,
+      "`validate` is offline and only resolves extends pointing at local files; use `gh-labeler plan` to check configs that extend another repository.",
+    );
+  }
+  return fetcher;
+}
+
+/** Resolve an extends path against a directory inside a remote repository. */
+function resolveRepoPath(dir: string, path: string, spec: string): string {
+  const joined = path.startsWith("/") ? path.slice(1) : posix.join(dir, path);
+  const normalized = posix.normalize(joined);
+  if (normalized === ".." || normalized.startsWith("../")) {
+    throw new ConfigError(
+      `Extends path escapes the repository: "${spec}"`,
+      "Paths in a config fetched from a repository resolve inside that same repository.",
+    );
+  }
+  return normalized;
+}
+
+interface LoadedBase {
+  config: LabelConfigFile;
+  origin: ConfigOrigin;
+  id: string;
+}
+
+async function loadExtendsBase(
+  spec: string,
+  origin: ConfigOrigin,
+  fetcher: RemoteFileFetcher | undefined,
+): Promise<LoadedBase> {
+  const ref = parseExtendsRef(spec);
+
+  if (ref.kind === "path") {
+    if (origin.kind === "local") {
+      const path = resolve(origin.dir, ref.path);
+      if (!existsSync(path)) {
+        throw new ConfigError(
+          `Extends target not found: ${path}`,
+          `Referenced as "${spec}" from the extending config.`,
+        );
+      }
+      return {
+        config: loadConfigFile(path),
+        origin: { kind: "local", dir: dirname(path) },
+        id: path,
+      };
+    }
+    const path = resolveRepoPath(origin.dir, ref.path, spec);
+    const { config } = await fetchRemoteConfigFile(requireFetcher(fetcher, spec), {
+      owner: origin.owner,
+      repo: origin.repo,
+      path,
+    });
+    return {
+      config,
+      origin: { kind: "remote", owner: origin.owner, repo: origin.repo, dir: posix.dirname(path) },
+      id: remoteId(origin.owner, origin.repo, path),
+    };
+  }
+
+  const { config, path } = await fetchRemoteConfigFile(requireFetcher(fetcher, spec), ref);
+  return {
+    config,
+    origin: { kind: "remote", owner: ref.owner, repo: ref.repo, dir: posix.dirname(path) },
+    id: remoteId(ref.owner, ref.repo, path),
+  };
+}
+
+async function resolveExtendsChain(
+  config: LabelConfigFile,
+  origin: ConfigOrigin,
+  fetcher: RemoteFileFetcher | undefined,
+  stack: string[],
+): Promise<ConfigEntry[]> {
+  let merged: ConfigEntry[] = [];
+  for (const spec of config.extends ?? []) {
+    // Sequential by design: merge order must follow the extends order, and
+    // cycle detection tracks the current chain.
+    // eslint-disable-next-line no-await-in-loop
+    const base = await loadExtendsBase(spec, origin, fetcher);
+    assertNoExtendsCycle(stack, base.id);
+    // eslint-disable-next-line no-await-in-loop
+    const baseLabels = await resolveExtendsChain(base.config, base.origin, fetcher, [
+      ...stack,
+      base.id,
+    ]);
+    merged = mergeLabelEntries(merged, baseLabels);
+  }
+  return mergeLabelEntries(merged, config.labels);
+}
+
+async function resolveExtendedConfig(
+  config: LabelConfigFile,
+  origin: ConfigOrigin,
+  fetcher: RemoteFileFetcher | undefined,
+  stack: string[],
+): Promise<LabelConfigFile> {
+  if (!config.extends || config.extends.length === 0) {
+    return config;
+  }
+  const labels = await resolveExtendsChain(config, origin, fetcher, stack);
+  validateMergedAliases(labels);
+  const resolved: LabelConfigFile = { labels };
+  // Deliberately not inheriting prune: a shared base config must not be able
+  // to switch on deletions for every repository that extends it.
+  if (config.prune !== undefined) {
+    resolved.prune = config.prune;
+  }
+  return resolved;
+}
+
+/**
+ * Resolve a locally loaded config's `extends` chain. `configPath` is null for
+ * stdin (paths then resolve against the working directory). Remote refs need
+ * a fetcher; without one they fail with a config error.
+ */
+export function resolveConfigExtends(
+  config: LabelConfigFile,
+  configPath: string | null,
+  fetcher?: RemoteFileFetcher,
+): Promise<LabelConfigFile> {
+  const path = configPath === null ? null : resolve(configPath);
+  const origin: ConfigOrigin = {
+    kind: "local",
+    dir: path === null ? process.cwd() : dirname(path),
+  };
+  return resolveExtendedConfig(config, origin, fetcher, path === null ? [] : [path]);
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -12,6 +12,7 @@ import {
   parseConfig,
   parseRemoteConfigRef,
   type RemoteFileFetcher,
+  resolveConfigExtends,
   serializeConfigDocument,
 } from "#config/index.js";
 import { ConfigError } from "#errors.js";
@@ -140,6 +141,21 @@ describe(parseConfig, () => {
       parseConfig('[{"name":"bug","color":"#ff0000","aliases":["bug"]}]', "json"),
     ).toThrow(/alias "bug"/u);
   });
+
+  it("normalizes extends to an array", () => {
+    expect(parseConfig('{"labels":[],"extends":"./base.yml"}', "json").extends).toStrictEqual([
+      "./base.yml",
+    ]);
+    expect(
+      parseConfig('{"labels":[],"extends":["./a.yml","org/repo"]}', "json").extends,
+    ).toStrictEqual(["./a.yml", "org/repo"]);
+  });
+
+  it("rejects invalid extends values", () => {
+    expect(() => parseConfig('{"labels":[],"extends":5}', "json")).toThrow(ConfigError);
+    expect(() => parseConfig('{"labels":[],"extends":[""]}', "json")).toThrow(ConfigError);
+    expect(() => parseConfig('{"labels":[],"extends":[42]}', "json")).toThrow(ConfigError);
+  });
 });
 
 describe(loadConfigFile, () => {
@@ -254,6 +270,263 @@ describe(fetchRemoteConfig, () => {
     await expect(promise).rejects.toMatchObject({
       hint: expect.stringContaining(CONVENTION_CONFIG_FILES[0]),
     });
+  });
+});
+
+function fakeRepoFetcher(repos: Record<string, Record<string, string>>): RemoteFileFetcher {
+  return {
+    fetchFile: (owner, repo, path) => Promise.resolve(repos[`${owner}/${repo}`]?.[path] ?? null),
+  };
+}
+
+function writeConfig(dir: string, name: string, doc: unknown): string {
+  const path = join(dir, name);
+  writeFileSync(path, JSON.stringify(doc));
+  return path;
+}
+
+describe(resolveConfigExtends, () => {
+  it("returns a config without extends unchanged", async () => {
+    const config = parseConfig('[{"name":"bug","color":"#ff0000"}]', "json");
+    await expect(resolveConfigExtends(config, null)).resolves.toBe(config);
+  });
+
+  it("merges base labels and overrides by name, case-insensitively", async () => {
+    const dir = tempDir();
+    writeConfig(dir, "base.json", {
+      labels: [
+        { name: "Bug", color: "#ff0000", description: "from base" },
+        { name: "docs", color: "#0075ca" },
+      ],
+    });
+    const childPath = writeConfig(dir, "child.json", {
+      extends: "./base.json",
+      labels: [
+        { name: "bug", color: "#00ff00" },
+        { name: "extra", color: "#000000" },
+      ],
+    });
+
+    const resolved = await resolveConfigExtends(loadConfigFile(childPath), childPath);
+    expect(resolved.labels).toStrictEqual([
+      { name: "bug", color: "#00ff00" },
+      { name: "docs", color: "#0075ca" },
+      { name: "extra", color: "#000000" },
+    ]);
+  });
+
+  it("lets the extending config cancel an inherited label with delete", async () => {
+    const dir = tempDir();
+    writeConfig(dir, "base.json", { labels: [{ name: "wontfix", color: "#ffffff" }] });
+    const childPath = writeConfig(dir, "child.json", {
+      extends: "./base.json",
+      labels: [{ name: "wontfix", delete: true }],
+    });
+
+    const resolved = await resolveConfigExtends(loadConfigFile(childPath), childPath);
+    expect(resolved.labels).toStrictEqual([{ name: "wontfix", delete: true }]);
+  });
+
+  it("does not inherit prune from a base config", async () => {
+    const dir = tempDir();
+    writeConfig(dir, "base.json", {
+      labels: [{ name: "bug", color: "#ff0000" }],
+      prune: true,
+    });
+    const childPath = writeConfig(dir, "child.json", { extends: "./base.json", labels: [] });
+
+    const resolved = await resolveConfigExtends(loadConfigFile(childPath), childPath);
+    expect(resolved.prune).toBeUndefined();
+  });
+
+  it("keeps the extending config's own prune", async () => {
+    const dir = tempDir();
+    writeConfig(dir, "base.json", {
+      labels: [{ name: "bug", color: "#ff0000" }],
+      prune: true,
+    });
+    const childPath = writeConfig(dir, "child.json", {
+      extends: "./base.json",
+      labels: [],
+      prune: false,
+    });
+
+    const resolved = await resolveConfigExtends(loadConfigFile(childPath), childPath);
+    expect(resolved.prune).toBe(false);
+  });
+
+  it("resolves nested extends depth-first", async () => {
+    const dir = tempDir();
+    writeConfig(dir, "c.json", { labels: [{ name: "from-c", color: "#111111" }] });
+    writeConfig(dir, "b.json", {
+      extends: "./c.json",
+      labels: [{ name: "from-b", color: "#222222" }],
+    });
+    const aPath = writeConfig(dir, "a.json", {
+      extends: "./b.json",
+      labels: [{ name: "from-a", color: "#333333" }],
+    });
+
+    const resolved = await resolveConfigExtends(loadConfigFile(aPath), aPath);
+    expect(resolved.labels.map((label) => label.name)).toStrictEqual([
+      "from-c",
+      "from-b",
+      "from-a",
+    ]);
+  });
+
+  it("merges multiple bases in order, later bases winning", async () => {
+    const dir = tempDir();
+    writeConfig(dir, "b1.json", {
+      labels: [
+        { name: "shared", color: "#111111" },
+        { name: "only-b1", color: "#222222" },
+      ],
+    });
+    writeConfig(dir, "b2.json", { labels: [{ name: "shared", color: "#333333" }] });
+    const childPath = writeConfig(dir, "child.json", {
+      extends: ["./b1.json", "./b2.json"],
+      labels: [],
+    });
+
+    const resolved = await resolveConfigExtends(loadConfigFile(childPath), childPath);
+    expect(resolved.labels).toStrictEqual([
+      { name: "shared", color: "#333333" },
+      { name: "only-b1", color: "#222222" },
+    ]);
+  });
+
+  it("rejects circular extends", async () => {
+    const dir = tempDir();
+    writeConfig(dir, "a.json", { extends: "./b.json", labels: [] });
+    const bPath = writeConfig(dir, "b.json", { extends: "./a.json", labels: [] });
+
+    await expect(resolveConfigExtends(loadConfigFile(bPath), bPath)).rejects.toThrow(
+      /Circular extends/u,
+    );
+  });
+
+  it("fails when a local base file is missing", async () => {
+    const dir = tempDir();
+    const childPath = writeConfig(dir, "child.json", { extends: "./missing.json", labels: [] });
+
+    await expect(resolveConfigExtends(loadConfigFile(childPath), childPath)).rejects.toThrow(
+      /Extends target not found/u,
+    );
+  });
+
+  it("rejects an extends reference that is neither a path nor owner/repo", async () => {
+    const dir = tempDir();
+    const childPath = writeConfig(dir, "child.json", { extends: "base.json", labels: [] });
+
+    await expect(resolveConfigExtends(loadConfigFile(childPath), childPath)).rejects.toThrow(
+      /Invalid extends reference/u,
+    );
+  });
+
+  it("fails on remote extends without a fetcher", async () => {
+    const dir = tempDir();
+    const childPath = writeConfig(dir, "child.json", { extends: "org/labels", labels: [] });
+
+    await expect(resolveConfigExtends(loadConfigFile(childPath), childPath)).rejects.toThrow(
+      /without GitHub access/u,
+    );
+  });
+
+  it("resolves remote extends through a fetcher", async () => {
+    const dir = tempDir();
+    const childPath = writeConfig(dir, "child.json", {
+      extends: "org/labels",
+      labels: [{ name: "local", color: "#111111" }],
+    });
+    const fetcher = fakeRepoFetcher({
+      "org/labels": {
+        ".gh-labeler.json": JSON.stringify({ labels: [{ name: "shared", color: "#222222" }] }),
+      },
+    });
+
+    const resolved = await resolveConfigExtends(loadConfigFile(childPath), childPath, fetcher);
+    expect(resolved.labels.map((label) => label.name)).toStrictEqual(["shared", "local"]);
+  });
+
+  it("rejects cross-file alias contradictions after merging", async () => {
+    const dir = tempDir();
+    writeConfig(dir, "base.json", {
+      labels: [{ name: "bug", color: "#ff0000", aliases: ["defect"] }],
+    });
+    const childPath = writeConfig(dir, "child.json", {
+      extends: "./base.json",
+      labels: [{ name: "defect", color: "#00ff00" }],
+    });
+
+    await expect(resolveConfigExtends(loadConfigFile(childPath), childPath)).rejects.toThrow(
+      /alias "defect"/u,
+    );
+  });
+});
+
+describe("fetchRemoteConfig with extends", () => {
+  it("resolves extends inside the same repository, relative to the config file", async () => {
+    const fetcher = fakeRepoFetcher({
+      "o/r": {
+        "configs/labels.json": JSON.stringify({
+          extends: "./base.json",
+          labels: [{ name: "child", color: "#111111" }],
+        }),
+        "configs/base.json": JSON.stringify({ labels: [{ name: "base", color: "#222222" }] }),
+      },
+    });
+
+    const config = await fetchRemoteConfig(fetcher, {
+      owner: "o",
+      repo: "r",
+      path: "configs/labels.json",
+    });
+    expect(config.labels.map((label) => label.name)).toStrictEqual(["base", "child"]);
+  });
+
+  it("resolves extends from a convention file at the repository root", async () => {
+    const fetcher = fakeRepoFetcher({
+      "o/r": {
+        ".gh-labeler.json": JSON.stringify({
+          extends: "./base.json",
+          labels: [{ name: "child", color: "#111111" }],
+        }),
+        "base.json": JSON.stringify({ labels: [{ name: "base", color: "#222222" }] }),
+      },
+    });
+
+    const config = await fetchRemoteConfig(fetcher, { owner: "o", repo: "r" });
+    expect(config.labels.map((label) => label.name)).toStrictEqual(["base", "child"]);
+  });
+
+  it("rejects an extends path that escapes the repository", async () => {
+    const fetcher = fakeRepoFetcher({
+      "o/r": {
+        "configs/labels.json": JSON.stringify({ extends: "../../evil.json", labels: [] }),
+      },
+    });
+
+    await expect(
+      fetchRemoteConfig(fetcher, { owner: "o", repo: "r", path: "configs/labels.json" }),
+    ).rejects.toThrow(/escapes the repository/u);
+  });
+
+  it("follows extends into another repository", async () => {
+    const fetcher = fakeRepoFetcher({
+      "o/r": {
+        ".gh-labeler.json": JSON.stringify({
+          extends: "org/shared:labels.json",
+          labels: [{ name: "local", color: "#111111" }],
+        }),
+      },
+      "org/shared": {
+        "labels.json": JSON.stringify({ labels: [{ name: "shared", color: "#222222" }] }),
+      },
+    });
+
+    const config = await fetchRemoteConfig(fetcher, { owner: "o", repo: "r" });
+    expect(config.labels.map((label) => label.name)).toStrictEqual(["shared", "local"]);
   });
 });
 


### PR DESCRIPTION
- Add `extends` to the config object form: inherit labels from a local path (`./base.yml`) or another repository (`owner/repo[:path]`)
- Merge bases in listed order with the extending file's labels winning by case-insensitive name; `delete: true` cancels an inherited label
- Support nested extends with cycle detection and never inherit `prune` from a base
- Keep `validate` offline: local extends resolve, remote refs fail with a hint pointing at `plan`
- Update JSON schema, docs, and config tests for extends resolution