### PR TITLE
[main] ci: add shared label sync workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,2 +1,7 @@
-- name: "type: bump-version"
-  color: "#f4e2e4"
+# Inherits the shared base label set (Conventional Commits types,
+# type: bump-version, skip-ci):
+# https://github.com/kkhys/.github/blob/main/.github/labels.yml
+extends: kkhys/.github
+
+# No repository-specific labels
+labels: []

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,30 @@
+name: Sync Labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
+  # Pick up changes to the shared base config (kkhys/.github), which
+  # cannot trigger this workflow on its own.
+  schedule:
+    - cron: "0 18 * * 0" # Mondays 03:00 JST
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    name: Sync Labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: kkhys/gh-labeler-actions@a0a81fc9ecec5ee339c4c216ea6ff1b75b94c3fb # v1.0.0
+        with:
+          # Mirror the config exactly, matching the previous
+          # github-label-sync behavior of deleting undeclared labels.
+          prune: true


### PR DESCRIPTION
- Add Sync Labels workflow that runs on pushes to main touching label config, a weekly schedule, and manual dispatch
- Switch .github/labels.yml to extend the shared base label set from kkhys/.github instead of declaring labels locally
- Sync labels with kkhys/gh-labeler-actions pinned to v1.0.0 by commit SHA
- Enable prune to delete undeclared labels, matching the previous github-label-sync behavior